### PR TITLE
opt: curator use 'content' key instead of 'answer'

### DIFF
--- a/ace/core/curator.py
+++ b/ace/core/curator.py
@@ -135,7 +135,7 @@ class Curator:
             for op in operations:
                 try:
                     op_type = op.get('type', 'UNKNOWN') if isinstance(op, dict) else 'INVALID'
-                    op_reason = op.get('reason', 'No reason given') if isinstance(op, dict) else 'Invalid operation format'
+                    op_reason = op.get('content', 'No reason given') if isinstance(op, dict) else 'Invalid operation format'
                     print(f"  - {op_type}: {op_reason}")
                 except Exception as e:
                     print(f"  - UNKNOWN: Error logging operation: {e}")


### PR DESCRIPTION
Background: applying ACE to a Text2SQL task.

Problem: curator use 'answer' as the key to retrieve llm suggestions to append to the playbook, but the output format is like [['type': 'xxx', 'section': 'xxx', 'content': 'xxx'] (e.g. [{'type': 'ADD', 'section': 'STRATEGIES_AND_HARD_RULES', 'content': "Before writing filters, examine the schema to determine where attributes are stored. For example, a driver's city is likely in the drivers table, not the rides table. Always join from the entity table when filtering by entity properties."}]

Should use key 'content' instead?