### PR TITLE
Add new provider commonstack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ SAMBANOVA_API_KEY=your_sambanova_api_key
 # Together API Key
 # Get your API key from: https://together.ai/
 TOGETHER_API_KEY=your_together_api_key
+
+# Commonstack API Key
+# Get your API key from: https://commonstack.ai/
+COMMONSTACK_API_KEY=your_commonstack_api_key

--- a/EXTENDING_ACE.md
+++ b/EXTENDING_ACE.md
@@ -280,7 +280,7 @@ def main():
         print("Using empty playbook as initial playbook\n")
     
     # Initialize ACE
-    api_provider = "sambanova" # or "togehter", "openai"
+    api_provider = "sambanova" # or "together", "openai", "commonstack"
     ace_system = ACE(
         api_provider=api_provider,
         generator_model="DeepSeek-V3.1",  # Or your preferred model

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ from ace import ACE
 from utils import initialize_clients
 
 # Initialize API clients
-api_provider = "sambanova" # or "together", "openai"
+api_provider = "sambanova" # or "together", "openai", "commonstack"
 
 # Initialize ACE system
 ace_system = ACE(
@@ -201,7 +201,7 @@ uv run python -m eval.finance.run \
 | `--save_path` | Directory to save results | Required |
 | `--initial_playbook_path` | Path to initial playbook | Optional |
 | `--mode` | Run mode: 'offline' for offline training with validation, 'online' for online training and testing on test split, 'eval_only' for evaluation only | `offline` |
-| `--api_provider` | API provider for LLM calls. Choose from ['sambanova', 'together', 'openai'] | `sambanova` |
+| `--api_provider` | API provider for LLM calls. Choose from ['sambanova', 'together', 'openai', 'commonstack'] | `sambanova` |
 | `--num_epochs` | Number of training epochs | 1 |
 | `--max_num_rounds` | Max reflection rounds for incorrect answers | 3 |
 | `--curator_frequency` | Run curator every N steps | 1 |

--- a/eval/finance/run.py
+++ b/eval/finance/run.py
@@ -30,7 +30,7 @@ def parse_args():
     
     # Model configuration
     parser.add_argument("--api_provider", type=str, default="sambanova",
-                        choices=["sambanova", "together", "openai"], help="API provider")
+                        choices=["sambanova", "together", "openai", "commonstack"], help="API provider")
     parser.add_argument("--generator_model", type=str, 
                         default="DeepSeek-V3.1",
                         help="Model for generator")

--- a/eval/mind2web/run.py
+++ b/eval/mind2web/run.py
@@ -23,7 +23,7 @@ def parse_args():
 
     # Model configuration
     parser.add_argument("--api_provider", type=str, default="sambanova",
-                        choices=["sambanova", "together", "openai"], help="API provider")
+                        choices=["sambanova", "together", "openai", "commonstack"], help="API provider")
     parser.add_argument("--generator_model", type=str,
                         default="DeepSeek-V3.1",
                         help="Model for generator")

--- a/eval/mind2web2/run.py
+++ b/eval/mind2web2/run.py
@@ -23,7 +23,7 @@ def parse_args():
 
     # Model configuration
     parser.add_argument("--api_provider", type=str, default="sambanova",
-                        choices=["sambanova", "together", "openai"], help="API provider")
+                        choices=["sambanova", "together", "openai", "commonstack"], help="API provider")
     parser.add_argument("--generator_model", type=str,
                         default="DeepSeek-V3.1",
                         help="Model for generator")

--- a/tutorials/ExtendingDatasets.md
+++ b/tutorials/ExtendingDatasets.md
@@ -280,7 +280,7 @@ def main():
         print("Using empty playbook as initial playbook\n")
     
     # Initialize ACE
-    api_provider = "sambanova" # or "togehter", "openai"
+    api_provider = "sambanova" # or "together", "openai", "commonstack"
     ace_system = ACE(
         api_provider=api_provider,
         generator_model="DeepSeek-V3.1",  # Or your preferred model

--- a/utils.py
+++ b/utils.py
@@ -31,14 +31,22 @@ def initialize_clients(api_provider):
         api_key = os.getenv('OPENAI_API_KEY', '')
         if not api_key:
             raise ValueError("OpenAI api key not found in environment variables")
+    elif api_provider == "commonstack":
+        # Use Commonstack API
+        base_url = "https://api.commonstack.ai/v1"
+        api_key = os.getenv('COMMONSTACK_API_KEY', '')
+        if not api_key:
+            raise ValueError("Commonstack api key not found in environment variables")
     else:
-        raise ValueError((f"Invalid api_provider name: {api_provider}. Must be 'sambanova', 'together', or 'openai'"))
+        raise ValueError(
+            f"Invalid api_provider name: {api_provider}. Must be 'sambanova', 'together', 'openai', or 'commonstack'"
+        )
         
     generator_client = openai.OpenAI(api_key=api_key, base_url=base_url)
     reflector_client = openai.OpenAI(api_key=api_key, base_url=base_url)
     curator_client = openai.OpenAI(api_key=api_key, base_url=base_url)
     
-    print("Using Together API for all models")
+    print(f"Using {api_provider} API for all models")
     return generator_client, reflector_client, curator_client
 
 def get_section_slug(section_name):


### PR DESCRIPTION
## Summary
This PR adds `commonstack` as a new OpenAI-compatible provider in ACE, including runtime config, CLI options, and docs updates.

## Changes
- Add `commonstack` support in `utils.initialize_clients`:
  - Base URL: `https://api.commonstack.ai/v1`
  - Env key: `COMMONSTACK_API_KEY`
  - Provider validation message updated
  - Provider log message changed to dynamic output
- Extend `--api_provider` choices to include `commonstack` in:
  - `eval/finance/run.py`
  - `eval/mind2web/run.py`
  - `eval/mind2web2/run.py`
- Update `.env.example` with:
  - `COMMONSTACK_API_KEY=your_commonstack_api_key`
- Update docs to include `commonstack` in provider examples/options:
  - `README.md`
  - `EXTENDING_ACE.md`
  - `tutorials/ExtendingDatasets.md`
- Fix typo in docs comment: `togehter` -> `together`

## Validation
- Syntax check passed:
  - `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile utils.py eval/finance/run.py eval/mind2web/run.py eval/mind2web2/run.py`
- Provider wiring validated via local smoke run path:
  - `results/commonstack_smoke/...`

## Backward Compatibility
- Existing providers (`sambanova`, `together`, `openai`) are unchanged.
- This is an additive change; no breaking interface changes.

## Notes
- `llm.py` currently routes only `openai` to `max_completion_tokens`, others use `max_tokens`.
- If Commonstack requires `max_completion_tokens` for specific models, a small follow-up can add a provider-specific switch.
