### PR TITLE
feat: add DeepSeek as an API provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ TOGETHER_API_KEY=your_together_api_key
 # Commonstack API Key
 # Get your API key from: https://commonstack.ai/
 COMMONSTACK_API_KEY=your_commonstack_api_key
+
+# DeepSeek API Key
+# Get your API key from: https://platform.deepseek.com/
+DEEPSEEK_API_KEY=your_deepseek_api_key

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ from ace import ACE
 from utils import initialize_clients
 
 # Initialize API clients
-api_provider = "sambanova" # or "together", "openai", "commonstack"
+api_provider = "sambanova" # or "together", "openai", "commonstack", "deepseek"
 
 # Initialize ACE system
 ace_system = ACE(
@@ -201,7 +201,7 @@ uv run python -m eval.finance.run \
 | `--save_path` | Directory to save results | Required |
 | `--initial_playbook_path` | Path to initial playbook | Optional |
 | `--mode` | Run mode: 'offline' for offline training with validation, 'online' for online training and testing on test split, 'eval_only' for evaluation only | `offline` |
-| `--api_provider` | API provider for LLM calls. Choose from ['sambanova', 'together', 'openai', 'commonstack'] | `sambanova` |
+| `--api_provider` | API provider for LLM calls. Choose from ['sambanova', 'together', 'openai', 'commonstack', 'deepseek'] | `sambanova` |
 | `--num_epochs` | Number of training epochs | 1 |
 | `--max_num_rounds` | Max reflection rounds for incorrect answers | 3 |
 | `--curator_frequency` | Run curator every N steps | 1 |

--- a/eval/finance/run.py
+++ b/eval/finance/run.py
@@ -30,7 +30,7 @@ def parse_args():
     
     # Model configuration
     parser.add_argument("--api_provider", type=str, default="sambanova",
-                        choices=["sambanova", "together", "openai", "commonstack"], help="API provider")
+                        choices=["sambanova", "together", "openai", "commonstack", "deepseek"], help="API provider")
     parser.add_argument("--generator_model", type=str, 
                         default="DeepSeek-V3.1",
                         help="Model for generator")

--- a/eval/mind2web/run.py
+++ b/eval/mind2web/run.py
@@ -23,7 +23,7 @@ def parse_args():
 
     # Model configuration
     parser.add_argument("--api_provider", type=str, default="sambanova",
-                        choices=["sambanova", "together", "openai", "commonstack"], help="API provider")
+                        choices=["sambanova", "together", "openai", "commonstack", "deepseek"], help="API provider")
     parser.add_argument("--generator_model", type=str,
                         default="DeepSeek-V3.1",
                         help="Model for generator")

--- a/eval/mind2web2/run.py
+++ b/eval/mind2web2/run.py
@@ -23,7 +23,7 @@ def parse_args():
 
     # Model configuration
     parser.add_argument("--api_provider", type=str, default="sambanova",
-                        choices=["sambanova", "together", "openai", "commonstack"], help="API provider")
+                        choices=["sambanova", "together", "openai", "commonstack", "deepseek"], help="API provider")
     parser.add_argument("--generator_model", type=str,
                         default="DeepSeek-V3.1",
                         help="Model for generator")

--- a/utils.py
+++ b/utils.py
@@ -37,9 +37,15 @@ def initialize_clients(api_provider):
         api_key = os.getenv('COMMONSTACK_API_KEY', '')
         if not api_key:
             raise ValueError("Commonstack api key not found in environment variables")
+    elif api_provider == "deepseek":
+        # Use DeepSeek official API (OpenAI-compatible)
+        base_url = "https://api.deepseek.com/v1"
+        api_key = os.getenv('DEEPSEEK_API_KEY', '')
+        if not api_key:
+            raise ValueError("DeepSeek api key not found in environment variables")
     else:
         raise ValueError(
-            f"Invalid api_provider name: {api_provider}. Must be 'sambanova', 'together', 'openai', or 'commonstack'"
+            f"Invalid api_provider name: {api_provider}. Must be 'sambanova', 'together', 'openai', 'commonstack', or 'deepseek'"
         )
         
     generator_client = openai.OpenAI(api_key=api_key, base_url=base_url)


### PR DESCRIPTION
## What

Adds the official DeepSeek endpoint (`https://api.deepseek.com/v1`, OpenAI-compatible) as a fifth `api_provider` option alongside `sambanova`, `together`, `openai`, and `commonstack`.

- `utils.py`: `initialize_clients` supports `api_provider="deepseek"` via `DEEPSEEK_API_KEY`; the invalid-provider error message now lists all five options
- `eval/{finance,mind2web,mind2web2}/run.py`: `"deepseek"` added to `--api_provider` choices
- `.env.example` / `README.md`: document the new provider

## Why

The README's own examples default to `DeepSeek-V3.1` (through SambaNova). Supporting DeepSeek's first-party API lets users run ACE directly against the model vendor — often the cheapest option, and the natural choice for users in regions where DeepSeek is the most accessible frontier-quality API.

## Verified

Ran the finance formula task end-to-end (offline adaptation, generator/reflector/curator all on `deepseek-chat`): playbook grew structured bullets across sections with curator delta logging working as expected, and the final test evaluation completed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
